### PR TITLE
Add macOS DMG build GitHub Actions workflow

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -1,0 +1,67 @@
+name: Build Mac App
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: opencassava
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opencassava/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            opencassava/src-tauri -> target
+
+      - name: Install macOS build dependencies
+        run: brew install cmake
+        working-directory: .
+
+      - name: Prepare whisper-rs
+        run: pwsh opencassava/scripts/prepare-whisper.ps1
+        working-directory: .
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build macOS DMG
+        run: npm run tauri -- build --bundles dmg
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencassava-mac-dmg
+          path: target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Publish GitHub release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
Mirrors the pattern of ubuntu-release.yml and windows-release.yml.
Runs on macos-latest, installs cmake via Homebrew, prepares whisper-rs
using the existing PowerShell script, and builds a DMG with Tauri.

https://claude.ai/code/session_01WUoLgbeVUBBx5Lz6YLWeNz