### PR TITLE
Fix release to include all platform builds

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -2,9 +2,6 @@ name: Build Mac App
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write
@@ -60,8 +57,3 @@ jobs:
           path: target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 
-      - name: Publish GitHub release assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: target/release/bundle/dmg/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,179 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: powershell
+        working-directory: opencassava
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opencassava/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            opencassava/src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: npm.cmd ci
+
+      - name: Build Windows installers
+        run: npm.cmd run tauri -- build --bundles nsis,msi
+
+      - name: Upload Windows bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencassava-windows-bundles
+          path: |
+            target/release/bundle/nsis/*.exe
+            target/release/bundle/msi/*.msi
+          if-no-files-found: error
+
+  build-mac:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: opencassava
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opencassava/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            opencassava/src-tauri -> target
+
+      - name: Install macOS build dependencies
+        run: brew install cmake
+        working-directory: .
+
+      - name: Prepare whisper-rs
+        run: pwsh opencassava/scripts/prepare-whisper.ps1
+        working-directory: .
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build macOS DMG
+        run: npm run tauri -- build --bundles dmg
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencassava-mac-dmg
+          path: target/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+  build-ubuntu:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: opencassava
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opencassava/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            opencassava/src-tauri -> target
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev \
+            libssl-dev \
+            pkg-config \
+            libdbus-1-dev \
+            libasound2-dev \
+            cmake \
+            clang \
+            libclang-dev
+        working-directory: .
+
+      - name: Prepare whisper-rs
+        run: pwsh opencassava/scripts/prepare-whisper.ps1
+        working-directory: .
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build .deb package
+        run: npm run tauri -- build --bundles deb
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencassava-ubuntu-deb
+          path: target/release/bundle/deb/*.deb
+          if-no-files-found: error
+
+  publish-release:
+    needs: [build-windows, build-mac, build-ubuntu]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*

--- a/.github/workflows/ubuntu-release.yml
+++ b/.github/workflows/ubuntu-release.yml
@@ -2,9 +2,6 @@ name: Build Ubuntu App
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write
@@ -71,8 +68,3 @@ jobs:
           path: target/release/bundle/deb/*.deb
           if-no-files-found: error
 
-      - name: Publish GitHub release assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: target/release/bundle/deb/*.deb

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -2,9 +2,6 @@ name: Build Windows App
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write
@@ -53,10 +50,3 @@ jobs:
             target/release/bundle/msi/*.msi
           if-no-files-found: error
 
-      - name: Publish GitHub release assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            target/release/bundle/nsis/*.exe
-            target/release/bundle/msi/*.msi


### PR DESCRIPTION
## Summary
- Add consolidated `release.yml` workflow with parallel Windows, Mac, and Ubuntu build jobs plus a final `publish-release` job that waits for all three before creating the GitHub release
- Remove tag trigger and publish steps from individual platform workflows to eliminate the race condition where only the first-to-finish platform's files were attached to the release

## Test plan
- [ ] Push a `v*` tag and verify all three platform artifacts appear in the GitHub release
- [ ] Verify individual platform workflows (`windows-release.yml`, `mac-release.yml`, `ubuntu-release.yml`) still work via manual `workflow_dispatch`

https://claude.ai/code/session_012XkbecAJSeY3QS5K1uRY5h