### PR TITLE
Fix macOS release DMG build for whisper i8mm mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,15 @@ jobs:
 
       - name: Build macOS DMG
         run: npm run tauri -- build --bundles dmg
+        env:
+          # Apple Clang 17 on M-series sets __ARM_FEATURE_MATMUL_INT8 based on
+          # native CPU capabilities even when -mcpu=...+noi8mm disables i8mm at
+          # the code-generation level. This causes always_inline vmmlaq_s32 calls
+          # in ggml-cpu-quants.c to fail because the surrounding function is
+          # compiled without i8mm support. Force-undefine the macro so ggml
+          # falls back to its non-i8mm code path.
+          CFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
+          CXXFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation
- The tag-based `Release` macOS DMG build can fail on Apple Silicon because Apple Clang sets `__ARM_FEATURE_MATMUL_INT8`, which enables i8mm-only intrinsics (e.g. `vmmlaq_s32`) that are not supported by surrounding code paths and cause compilation errors in `whisper-rs-sys`/ggml.

### Description
- Add `CFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"` and `CXXFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"` to the `Build macOS DMG` step in `.github/workflows/release.yml` so the release workflow matches the existing workaround in the standalone mac workflow and forces ggml to use the non-i8mm code path on M-series runners.

### Testing
- No automated CI run has completed for this change yet; the fix mirrors the already-working `mac-release.yml` mitigation and will be validated by the GitHub Actions release workflow on the next tagged release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5e7af408c8323aa00663a7e5102ad)