### PR TITLE
fix(ci): correct mac DMG artifact path in workflows

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -63,6 +63,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opencassava-mac-dmg
-          path: target/release/bundle/dmg/*.dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opencassava-mac-dmg
-          path: target/release/bundle/dmg/*.dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 
   build-ubuntu:


### PR DESCRIPTION
### Motivation
- The GitHub Actions mac jobs upload the DMG from `target/release/bundle/dmg/*.dmg` but Tauri writes artifacts under `src-tauri/target/release/...`, causing the upload step to report "No files were found" despite a successful DMG build.

### Description
- Updated the DMG upload path in `.github/workflows/mac-release.yml` to `src-tauri/target/release/bundle/dmg/*.dmg` so it matches Tauri's output directory.
- Applied the same path fix in `.github/workflows/release.yml` for the tagged release mac job.

### Testing
- Parsed both modified workflow files with Ruby YAML loader using `ruby -e "require 'yaml'; YAML.load_file('...')"`, and the parse completed successfully.
- Attempted to parse with a Python one-liner using `yaml.safe_load` but it failed in this environment due to missing `PyYAML` (`ModuleNotFoundError`), so Ruby-based validation was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ed85565083239b5080ac602fb0ba)