### PR TITLE
fix(macos): inject -U__ARM_FEATURE_MATMUL_INT8 via cflag in build.rs patch

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -48,21 +48,12 @@ jobs:
         run: npm ci
 
       - name: Build macOS DMG
+        # The -U__ARM_FEATURE_MATMUL_INT8 flag is injected into the whisper-rs-sys
+        # cmake build via config.cflag()/config.cxxflag() inside prepare-whisper.ps1.
+        # That patch is necessary because the cmake Rust crate computes CMAKE_C_FLAGS
+        # from the cc crate and appends it after any config.define() calls, so env
+        # vars like CMAKE_C_FLAGS or CFLAGS are silently overridden.
         run: npm run tauri -- build --bundles dmg
-        env:
-          # Apple Clang on M-series may set __ARM_FEATURE_MATMUL_INT8 based on
-          # native CPU capabilities even when -mcpu=...+noi8mm disables i8mm at
-          # the code-generation level. This causes always_inline vmmlaq_s32 calls
-          # in ggml-cpu-quants.c to fail because the surrounding function is
-          # compiled without i8mm support. Force-undefine the macro so ggml
-          # falls back to its non-i8mm code path.
-          # CFLAGS/CXXFLAGS are read by cmake as initial CMAKE_C_FLAGS values;
-          # CMAKE_C_FLAGS/CMAKE_CXX_FLAGS are set explicitly as a belt-and-suspenders
-          # measure in case the cmake invocation overrides the environment defaults.
-          CFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CXXFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CMAKE_C_FLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CMAKE_CXX_FLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,21 +102,12 @@ jobs:
         run: npm ci
 
       - name: Build macOS DMG
+        # The -U__ARM_FEATURE_MATMUL_INT8 flag is injected into the whisper-rs-sys
+        # cmake build via config.cflag()/config.cxxflag() inside prepare-whisper.ps1.
+        # That patch is necessary because the cmake Rust crate computes CMAKE_C_FLAGS
+        # from the cc crate and appends it after any config.define() calls, so env
+        # vars like CMAKE_C_FLAGS or CFLAGS are silently overridden.
         run: npm run tauri -- build --bundles dmg
-        env:
-          # Apple Clang on M-series may set __ARM_FEATURE_MATMUL_INT8 based on
-          # native CPU capabilities even when -mcpu=...+noi8mm disables i8mm at
-          # the code-generation level. This causes always_inline vmmlaq_s32 calls
-          # in ggml-cpu-quants.c to fail because the surrounding function is
-          # compiled without i8mm support. Force-undefine the macro so ggml
-          # falls back to its non-i8mm code path.
-          # CFLAGS/CXXFLAGS are read by cmake as initial CMAKE_C_FLAGS values;
-          # CMAKE_C_FLAGS/CMAKE_CXX_FLAGS are set explicitly as a belt-and-suspenders
-          # measure in case the cmake invocation overrides the environment defaults.
-          CFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CXXFLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CMAKE_C_FLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
-          CMAKE_CXX_FLAGS: "-U__ARM_FEATURE_MATMUL_INT8"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4

--- a/opencassava/scripts/prepare-whisper.ps1
+++ b/opencassava/scripts/prepare-whisper.ps1
@@ -46,6 +46,26 @@ $buildText = $buildText.Replace(
   'let mut bindings = bindgen::Builder::default().header("wrapper.h");',
   'let bindings = bindgen::Builder::default().header("wrapper.h");'
 )
+# Patch build.rs: add -U__ARM_FEATURE_MATMUL_INT8 cflag for macOS ARM.
+#
+# Root cause: Apple Clang defines __ARM_FEATURE_MATMUL_INT8 based on the
+# native CPU's i8mm capability even when -mcpu=...+noi8mm disables i8mm code
+# generation.  ggml-cpu-quants.c uses always_inline vmmlaq_s32 (which requires
+# the i8mm target feature) inside a block guarded only by
+# #ifdef __ARM_FEATURE_MATMUL_INT8.  When that macro is defined but the
+# enclosing function is compiled without i8mm support the compiler emits a
+# fatal "always_inline function requires target feature 'i8mm'" error.
+#
+# Undefining the macro via cflag/cxxflag forces ggml to take the non-i8mm
+# fallback path.  Using config.cflag() / config.cxxflag() (rather than
+# config.define("CMAKE_C_FLAGS", ...)) is essential: the cmake Rust crate
+# builds its own CMAKE_C_FLAGS from the cc crate and appends it to the cmake
+# command AFTER any user-supplied .define() calls, overriding them.  The
+# cflag/cxxflag values, by contrast, are appended to the crate's own flags.
+$buildText = $buildText.Replace(
+  '    let destination = config.build();',
+  '    if target.contains("apple") { config.cflag("-U__ARM_FEATURE_MATMUL_INT8"); config.cxxflag("-U__ARM_FEATURE_MATMUL_INT8"); }' + "`n" + '    let destination = config.build();'
+)
 Set-Content -Path $sysBuild -Value $buildText -NoNewline
 
 $bindingsText = Get-Content $sysBindings -Raw


### PR DESCRIPTION
The previous attempt set CFLAGS/CMAKE_C_FLAGS env vars in the CI workflow,
but these have no effect: the cmake Rust crate (0.1.58) derives CMAKE_C_FLAGS
from the cc crate and appends it to the cmake invocation *after* any
config.define() calls, silently overriding user-supplied values.

Root cause of the build error:
- ggml detects that the GitHub Actions macos-14 runner's CPU does not support
  i8mm at runtime (CheckCXXSourceRuns fails) and adds +noi8mm to the compile
  flags.  However, Apple Clang still defines __ARM_FEATURE_MATMUL_INT8 based
  on the native CPU's hardware capability.
- ggml-cpu-quants.c wraps vmmlaq_s32 (an always_inline intrinsic that requires
  the i8mm target feature) in an #ifdef __ARM_FEATURE_MATMUL_INT8 block.
- Because the macro is defined but i8mm is disabled at the code-generation
  level the compiler emits: "always_inline function 'vmmlaq_s32' requires
  target feature 'i8mm'".

Fix:
- Patch prepare-whisper.ps1 to add an additional text replacement to the
  whisper-rs-sys build.rs: insert
      if target.contains("apple") {
          config.cflag("-U__ARM_FEATURE_MATMUL_INT8");
          config.cxxflag("-U__ARM_FEATURE_MATMUL_INT8");
      }
  immediately before config.build().  config.cflag()/cxxflag() values are
  appended to (not overridden by) the cmake crate's own CMAKE_C/CXX_FLAGS,
  ensuring -U__ARM_FEATURE_MATMUL_INT8 reaches the compiler.
- Remove the now-unnecessary (and misleading) env block from the CI workflow
  build steps; replace with a comment explaining the real fix location.

https://claude.ai/code/session_015AhjEtv1XYaDMFzTtsB5zk