### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/opencassava/src/components/NotesView.tsx
+++ b/opencassava/src/components/NotesView.tsx
@@ -16,6 +16,14 @@ const REGEN_INTERVALS = [
   { value: 600, label: "10 min" },
 ];
 
+function getPlainTextPreview(markdown: string, length: number): string {
+  const withoutCode = markdown.replace(/`[^`]*`/g, "");
+  const withoutLinks = withoutCode.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+  const withoutFormatting = withoutLinks.replace(/[*_#>/~-]+/g, " ");
+  const collapsedWhitespace = withoutFormatting.replace(/\s+/g, " ").trim();
+  return collapsedWhitespace.slice(0, length);
+}
+
 interface SummarySnapshot {
   timestamp: string;
   markdown: string;
@@ -531,7 +539,7 @@ export function NotesView({ sessionId, initialNotes, onNotesChange, isRunning }:
                           whiteSpace: "nowrap",
                         }}
                       >
-                        {entry.markdown.replace(/<[^>]+>/g, "").slice(0, 60)}
+                        {getPlainTextPreview(entry.markdown, 60)}
                       </div>
                     </button>
                   );

--- a/opencassava/src/components/NotesView.tsx
+++ b/opencassava/src/components/NotesView.tsx
@@ -19,7 +19,7 @@ const REGEN_INTERVALS = [
 function getPlainTextPreview(markdown: string, length: number): string {
   const withoutCode = markdown.replace(/`[^`]*`/g, "");
   const withoutLinks = withoutCode.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
-  const withoutFormatting = withoutLinks.replace(/[*_#>/~-]+/g, " ");
+  const withoutFormatting = withoutLinks.replace(/[*_#>~-]+/g, " ");
   const collapsedWhitespace = withoutFormatting.replace(/\s+/g, " ").trim();
   return collapsedWhitespace.slice(0, length);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/romeroej2/OpenCassava/security/code-scanning/1](https://github.com/romeroej2/OpenCassava/security/code-scanning/1)

General approach: avoid home‑grown regex “HTML sanitization”, especially with multi-character matches that can be incomplete. Here, we do not need to strip tags to be safe because React already escapes text. The best low-impact fix is to stop using the fragile regex entirely and instead render a plain-text preview derived from the Markdown by a safer, simpler transformation.

Best concrete fix for this snippet:

- Replace `entry.markdown.replace(/<[^>]+>/g, "").slice(0, 60)` with logic that:
  - Removes Markdown formatting such as `*`, `_`, `#`, backticks, and links, but
  - Does not attempt to partially sanitize HTML.
- Keep the behavior (a short, human-readable preview) while eliminating the problematic regex.
- Implement a tiny helper function within the same file to generate this preview in a predictable, safe way.

Implementation details in `opencassava/src/components/NotesView.tsx`:

1. Add a small helper (near the top of the file, after constants) like:

   ```ts
   function getPlainTextPreview(markdown: string, length: number): string {
     const withoutCode = markdown.replace(/`[^`]*`/g, "");
     const withoutLinks = withoutCode.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
     const withoutFormatting = withoutLinks.replace(/[*_#>/~-]+/g, " ");
     const collapsedWhitespace = withoutFormatting.replace(/\s+/g, " ").trim();
     return collapsedWhitespace.slice(0, length);
   }
   ```

   This deliberately avoids trying to strip HTML with `<…>` regexes; instead it just normalizes typical Markdown syntax.

2. Change line 534 to call this helper:

   ```tsx
   {getPlainTextPreview(entry.markdown, 60)}
   ```

No new imports are required; the helper uses only built-in string and regex features. Functionality remains the same in spirit (a concise, text-only summary), but we eliminate the incomplete multi-character sanitization pattern that CodeQL flags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
