### PR TITLE
fix(omni-asr): install pinned torch and cleanup CUDA packages on native Linux + add blackwell cuda variant

### DIFF
--- a/crates/opencassava-core/src/transcription/omni_asr.rs
+++ b/crates/opencassava-core/src/transcription/omni_asr.rs
@@ -4,15 +4,40 @@ use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
 const WORKER_SCRIPT: &str = include_str!("omni_asr_worker.py");
 const REQUIREMENTS: &str = include_str!("omni_asr_requirements.txt");
 const PYTORCH_CPU_INDEX: &str = "https://download.pytorch.org/whl/cpu";
 const PYTORCH_CUDA_INDEX: &str = "https://download.pytorch.org/whl/cu124";
+const PYTORCH_CUDA_BLACKWELL_INDEX: &str = "https://download.pytorch.org/whl/cu128";
 const FAIRSEQ2_CPU_INDEX: &str = "https://fair.pkg.atmeta.com/fairseq2/whl/pt2.6.0/cpu";
 const FAIRSEQ2_CUDA_INDEX: &str = "https://fair.pkg.atmeta.com/fairseq2/whl/pt2.6.0/cu124";
+const FAIRSEQ2_CUDA_BLACKWELL_INDEX: &str =
+    "https://fair.pkg.atmeta.com/fairseq2/whl/pt2.8.0/cu128";
+const FAIRSEQ2_VERSION: &str = "0.6";
+const TORCH_VERSION: &str = "2.6.0";
+const TORCHAUDIO_VERSION: &str = "2.6.0";
+const TORCH_BLACKWELL_VERSION: &str = "2.8.0";
+const TORCHAUDIO_BLACKWELL_VERSION: &str = "2.8.0";
+const INSTALL_LAYOUT_VERSION: &str = "3";
+const SNDFILE_LINK_SOURCE: &str = "libsndfile_x86_64.so";
+const SNDFILE_LINK_TARGET: &str = "libsndfile.so.1";
+const SNDFILE_LINK_SCRIPT: &str = "import _soundfile_data as sd,os,sys,pathlib; src=pathlib.Path(sd.__file__).parent/sys.argv[1]; dst=pathlib.Path(sys.prefix)/sys.argv[2]/sys.argv[3]; os.makedirs(str(dst.parent),exist_ok=True); dst.unlink(missing_ok=True); dst.symlink_to(src); print(str(src)+sys.argv[4]+str(dst))";
+const CUDA_RUNTIME_PACKAGES: &[&str] = &[
+    "triton",
+    "nvidia-nccl-cu12",
+    "nvidia-cublas-cu12",
+    "nvidia-cuda-cupti-cu12",
+    "nvidia-cuda-nvrtc-cu12",
+    "nvidia-cuda-runtime-cu12",
+    "nvidia-cudnn-cu12",
+    "nvidia-cufft-cu12",
+    "nvidia-curand-cu12",
+    "nvidia-cusolver-cu12",
+    "nvidia-cusparse-cu12",
+];
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -40,14 +65,17 @@ pub struct OmniAsrConfig {
 impl OmniAsrConfig {
     fn install_variant(&self) -> &'static str {
         if self.device.trim().eq_ignore_ascii_case("cuda") {
-            "cu124"
+            detect_cuda_install_variant(self.use_wsl)
         } else {
             "cpu"
         }
     }
 
     fn install_stamp_contents(&self) -> String {
-        format!("{REQUIREMENTS}\n# variant={}", self.install_variant())
+        format!(
+            "{REQUIREMENTS}\n# variant={}\n# layout={INSTALL_LAYOUT_VERSION}",
+            self.install_variant()
+        )
     }
 
     /// The stamp file used on native (non-WSL) installs.
@@ -165,6 +193,150 @@ pub fn locale_to_fairseq_lang(locale: &str) -> String {
     code.to_string()
 }
 
+fn torch_index_for_variant(variant: &str) -> &'static str {
+    match variant {
+        "cu124" => PYTORCH_CUDA_INDEX,
+        "cu128" => PYTORCH_CUDA_BLACKWELL_INDEX,
+        _ => PYTORCH_CPU_INDEX,
+    }
+}
+
+fn fairseq2_index_for_variant(variant: &str) -> &'static str {
+    match variant {
+        "cu124" => FAIRSEQ2_CUDA_INDEX,
+        "cu128" => FAIRSEQ2_CUDA_BLACKWELL_INDEX,
+        _ => FAIRSEQ2_CPU_INDEX,
+    }
+}
+
+fn torch_version_for_variant(variant: &str) -> &'static str {
+    if variant == "cu128" {
+        TORCH_BLACKWELL_VERSION
+    } else {
+        TORCH_VERSION
+    }
+}
+
+fn torchaudio_version_for_variant(variant: &str) -> &'static str {
+    if variant == "cu128" {
+        TORCHAUDIO_BLACKWELL_VERSION
+    } else {
+        TORCHAUDIO_VERSION
+    }
+}
+
+fn cuda_variant_for_gpu_info(name: Option<&str>, compute_capability: Option<&str>) -> &'static str {
+    if compute_capability
+        .and_then(parse_compute_capability_major)
+        .is_some_and(|major| major >= 10)
+    {
+        return "cu128";
+    }
+
+    if name.is_some_and(gpu_name_looks_blackwell) {
+        return "cu128";
+    }
+
+    "cu124"
+}
+
+fn parse_compute_capability_major(compute_capability: &str) -> Option<u32> {
+    compute_capability
+        .trim()
+        .split('.')
+        .next()?
+        .parse::<u32>()
+        .ok()
+}
+
+fn gpu_name_looks_blackwell(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+
+    if lower.contains("blackwell") {
+        return true;
+    }
+
+    ["rtx 5050", "rtx 5060", "rtx 5070", "rtx 5080", "rtx 5090"]
+        .iter()
+        .any(|model| lower.contains(model))
+}
+
+fn forced_cuda_install_variant() -> Option<&'static str> {
+    let value = std::env::var("OPENCASSAVA_OMNI_ASR_CUDA_VARIANT").ok()?;
+
+    match value.trim().to_ascii_lowercase().as_str() {
+        "cu124" | "legacy" => Some("cu124"),
+        "cu128" | "blackwell" => Some("cu128"),
+        _ => None,
+    }
+}
+
+fn detect_cuda_install_variant(use_wsl: bool) -> &'static str {
+    if let Some(variant) = forced_cuda_install_variant() {
+        return variant;
+    }
+
+    static NATIVE_VARIANT: OnceLock<&'static str> = OnceLock::new();
+    static WSL_VARIANT: OnceLock<&'static str> = OnceLock::new();
+
+    let cell = if use_wsl {
+        &WSL_VARIANT
+    } else {
+        &NATIVE_VARIANT
+    };
+
+    *cell.get_or_init(|| {
+        let compute_capability = nvidia_smi_query("compute_cap", use_wsl);
+        let name = nvidia_smi_query("name", use_wsl);
+
+        cuda_variant_for_gpu_info(name.as_deref(), compute_capability.as_deref())
+    })
+}
+
+fn nvidia_smi_query(field: &str, use_wsl: bool) -> Option<String> {
+    let query = format!("--query-gpu={field}");
+
+    command_output("nvidia-smi", &[query.as_str(), "--format=csv,noheader"]).or_else(|| {
+        use_wsl
+            .then(|| {
+                command_output(
+                    "wsl",
+                    &["nvidia-smi", query.as_str(), "--format=csv,noheader"],
+                )
+            })
+            .flatten()
+    })
+}
+
+fn command_output(command: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(command).args(args).output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        None
+    } else {
+        Some(stdout)
+    }
+}
+
+fn native_ld_library_path(venv_path: &Path, existing: Option<&std::ffi::OsStr>) -> String {
+    let mut value = venv_path.join("lib").to_string_lossy().into_owned();
+
+    if let Some(existing) = existing {
+        let existing = existing.to_string_lossy();
+        if !existing.is_empty() {
+            value.push(':');
+            value.push_str(&existing);
+        }
+    }
+
+    value
+}
+
 fn install_native_runtime_packages<F>(
     python_path: &Path,
     variant: &str,
@@ -173,23 +345,44 @@ fn install_native_runtime_packages<F>(
 where
     F: Fn(&str) + Send + Clone + 'static,
 {
-    // Only add the fairseq2 index — torch version is driven by omnilingual-asr's deps.
     #[cfg(target_os = "linux")]
     {
-        let fairseq2_index = if variant == "cu124" {
-            FAIRSEQ2_CUDA_INDEX
-        } else {
-            FAIRSEQ2_CPU_INDEX
-        };
+        let torch_version = torch_version_for_variant(variant);
+        let torchaudio_version = torchaudio_version_for_variant(variant);
+        let torch_index = torch_index_for_variant(variant);
+        let fairseq2_index = fairseq2_index_for_variant(variant);
+        let is_cuda = variant.starts_with("cu");
+
         run_command(
             Command::new(python_path)
                 .arg("-m")
                 .arg("pip")
                 .arg("install")
-                .arg("fairseq2")
+                .arg(format!("torch=={torch_version}"))
+                .arg(format!("torchaudio=={torchaudio_version}"))
+                .arg("--index-url")
+                .arg(torch_index),
+            if is_cuda {
+                "install torch CUDA builds"
+            } else {
+                "install torch CPU builds"
+            },
+            on_line.clone(),
+        )?;
+
+        run_command(
+            Command::new(python_path)
+                .arg("-m")
+                .arg("pip")
+                .arg("install")
+                .arg(format!("fairseq2=={FAIRSEQ2_VERSION}"))
                 .arg("--extra-index-url")
                 .arg(fairseq2_index),
-            &format!("install fairseq2 runtime ({variant})"),
+            if is_cuda {
+                "install fairseq2 CUDA"
+            } else {
+                "install fairseq2 CPU"
+            },
             on_line,
         )?;
     }
@@ -197,6 +390,56 @@ where
     #[cfg(not(target_os = "linux"))]
     let _ = (variant, on_line);
 
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn cleanup_native_cuda_packages<F>(python_path: &Path, on_line: F) -> Result<(), String>
+where
+    F: Fn(&str) + Send + Clone + 'static,
+{
+    let mut command = Command::new(python_path);
+    command.arg("-m").arg("pip").arg("uninstall").arg("-y");
+    for package in CUDA_RUNTIME_PACKAGES {
+        command.arg(package);
+    }
+
+    run_command(&mut command, "remove stray CUDA packages", on_line)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cleanup_native_cuda_packages<F>(python_path: &Path, on_line: F) -> Result<(), String>
+where
+    F: Fn(&str) + Send + Clone + 'static,
+{
+    let _ = (python_path, on_line);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn link_native_sndfile_for_fairseq2<F>(python_path: &Path, on_line: F) -> Result<(), String>
+where
+    F: Fn(&str) + Send + Clone + 'static,
+{
+    run_command(
+        Command::new(python_path)
+            .arg("-c")
+            .arg(SNDFILE_LINK_SCRIPT)
+            .arg(SNDFILE_LINK_SOURCE)
+            .arg("lib")
+            .arg(SNDFILE_LINK_TARGET)
+            .arg(" -> "),
+        "link libsndfile.so.1 for fairseq2",
+        on_line,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+fn link_native_sndfile_for_fairseq2<F>(python_path: &Path, on_line: F) -> Result<(), String>
+where
+    F: Fn(&str) + Send + Clone + 'static,
+{
+    let _ = (python_path, on_line);
     Ok(())
 }
 
@@ -290,24 +533,23 @@ pub fn check_wsl2_available() -> Result<(), String> {
 /// Check whether a suitable Python 3 is available on the native system PATH.
 /// Used by faster-whisper and parakeet on Windows (they do NOT use WSL2).
 pub fn check_native_python_available() -> Result<String, String> {
-    let candidates: &[(&str, &[&str])] = if cfg!(windows) {
-        &[("py", &["-3"]), ("python", &[])]
-    } else {
-        &[("python3", &[]), ("python", &[])]
-    };
+    let mut found_unsupported_python_version: Option<String> = None;
 
-    for (cmd, args) in candidates {
-        let ok = Command::new(cmd)
-            .args(args.iter())
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if ok {
-            return Ok(format!("{} {}", cmd, args.join(" ")).trim().to_string());
+    for candidate in native_python_candidates() {
+        if let Some(version) = command_version(&candidate.command, &candidate.prefix_args) {
+            if let Some(version) = unsupported_python_version(&version) {
+                found_unsupported_python_version = Some(version);
+                continue;
+            }
+
+            return Ok(candidate.display_command());
         }
+    }
+
+    if let Some(version) = found_unsupported_python_version {
+        return Err(format!(
+            "Python {version} is not supported for omni-asr. Install Python 3.10, 3.11, or 3.12."
+        ));
     }
 
     if cfg!(windows) {
@@ -416,6 +658,7 @@ where
     F: Fn(&str) + Send + Clone + 'static,
 {
     let python = detect_native_python()?;
+    let install_variant = config.install_variant();
 
     if !config.native_python_path().exists() {
         run_command(
@@ -440,7 +683,26 @@ where
         "upgrade pip for omni-asr",
         on_line.clone(),
     )?;
-    install_native_runtime_packages(&python_path, config.install_variant(), on_line.clone())?;
+    install_native_runtime_packages(&python_path, install_variant, on_line.clone())?;
+
+    #[cfg(target_os = "linux")]
+    let fairseq2_index = fairseq2_index_for_variant(install_variant);
+
+    #[cfg(target_os = "linux")]
+    run_command(
+        Command::new(&python_path)
+            .arg("-m")
+            .arg("pip")
+            .arg("install")
+            .arg("-r")
+            .arg(&config.requirements_path)
+            .arg("--extra-index-url")
+            .arg(fairseq2_index),
+        "install omni-asr runtime dependencies",
+        on_line.clone(),
+    )?;
+
+    #[cfg(not(target_os = "linux"))]
     run_command(
         Command::new(&python_path)
             .arg("-m")
@@ -449,8 +711,14 @@ where
             .arg("-r")
             .arg(&config.requirements_path),
         "install omni-asr runtime dependencies",
-        on_line,
+        on_line.clone(),
     )?;
+
+    if install_variant == "cpu" {
+        cleanup_native_cuda_packages(&python_path, on_line.clone())?;
+    }
+
+    link_native_sndfile_for_fairseq2(&python_path, on_line)?;
 
     Ok(())
 }
@@ -508,56 +776,43 @@ where
         on_line.clone(),
     )?;
 
-    let torch_index = if install_variant == "cu124" {
-        PYTORCH_CUDA_INDEX
-    } else {
-        PYTORCH_CPU_INDEX
-    };
-    let fairseq2_index = if install_variant == "cu124" {
-        FAIRSEQ2_CUDA_INDEX
-    } else {
-        FAIRSEQ2_CPU_INDEX
-    };
+    let torch_index = torch_index_for_variant(install_variant);
+    let fairseq2_index = fairseq2_index_for_variant(install_variant);
 
-    if install_variant != "cu124" {
-        // 3 (CPU). Pre-install torch + torchaudio from the CPU index BEFORE omnilingual-asr
-        //          can pull CUDA builds from PyPI. pip will not re-download them when
-        //          resolving requirements as long as the installed version satisfies the
-        //          omnilingual-asr constraint.
-        //          fairseq2 pt2.6.0 requires torch 2.6.x so we pin that version.
-        let install_torch_cpu = format!(
-            "'{venv_wsl}/bin/python3' -m pip install \
-             torch==2.6.0 torchaudio==2.6.0 \
-             --index-url {torch_index}"
-        );
-        run_wsl_command(
-            &install_torch_cpu,
-            "install torch CPU builds (WSL)",
-            on_line.clone(),
-        )?;
+    // 3. Pre-install torch + torchaudio from the selected PyTorch channel so
+    //    omnilingual-asr does not pull an incompatible default wheel later on.
+    let install_torch = format!(
+        "'{venv_wsl}/bin/python3' -m pip install \
+         torch=={} torchaudio=={} \
+         --index-url {torch_index}",
+        torch_version_for_variant(install_variant),
+        torchaudio_version_for_variant(install_variant)
+    );
+    run_wsl_command(
+        &install_torch,
+        if install_variant.starts_with("cu") {
+            "install torch CUDA builds (WSL)"
+        } else {
+            "install torch CPU builds (WSL)"
+        },
+        on_line.clone(),
+    )?;
 
-        // 4 (CPU). Pre-install fairseq2==0.6 from the Meta index.
-        let install_fairseq2 = format!(
-            "'{venv_wsl}/bin/python3' -m pip install 'fairseq2==0.6' \
-             --extra-index-url {fairseq2_index}"
-        );
-        run_wsl_command(
-            &install_fairseq2,
-            "install fairseq2 CPU (WSL)",
-            on_line.clone(),
-        )?;
-    } else {
-        // 3 (CUDA). Pre-install fairseq2==0.6 from the CUDA Meta index.
-        let install_fairseq2 = format!(
-            "'{venv_wsl}/bin/python3' -m pip install 'fairseq2==0.6' \
-             --extra-index-url {fairseq2_index}"
-        );
-        run_wsl_command(
-            &install_fairseq2,
-            "install fairseq2 CUDA (WSL)",
-            on_line.clone(),
-        )?;
-    }
+    // 4. Pre-install fairseq2 from the matching Meta index so fairseq2n pulls
+    //    the native extension built for the selected torch/CUDA stack.
+    let install_fairseq2 = format!(
+        "'{venv_wsl}/bin/python3' -m pip install 'fairseq2=={FAIRSEQ2_VERSION}' \
+         --extra-index-url {fairseq2_index}"
+    );
+    run_wsl_command(
+        &install_fairseq2,
+        if install_variant.starts_with("cu") {
+            "install fairseq2 CUDA (WSL)"
+        } else {
+            "install fairseq2 CPU (WSL)"
+        },
+        on_line.clone(),
+    )?;
 
     // 5. Install all requirements. torch/torchaudio are already installed for the CPU
     //    variant, so pip will keep them and only fetch the remaining packages from PyPI.
@@ -571,14 +826,12 @@ where
         on_line.clone(),
     )?;
 
-    if install_variant != "cu124" {
+    if install_variant == "cpu" {
         // 6 (CPU). Best-effort cleanup of stray CUDA packages.
         let cleanup_cuda_script = format!(
             "'{venv_wsl}/bin/python3' -m pip uninstall -y \
-             triton nvidia-nccl-cu12 nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 \
-             nvidia-cuda-nvrtc-cu12 nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 \
-             nvidia-cufft-cu12 nvidia-curand-cu12 nvidia-cusolver-cu12 \
-             nvidia-cusparse-cu12 2>/dev/null; exit 0"
+             {} 2>/dev/null; exit 0",
+            CUDA_RUNTIME_PACKAGES.join(" ")
         );
         run_wsl_command(
             &cleanup_cuda_script,
@@ -592,14 +845,8 @@ where
     //    Filenames are passed as sys.argv to avoid any quoting issues.
     let link_sndfile_script = format!(
         "'{venv_wsl}/bin/python3' -c \
-         'import _soundfile_data as sd,os,sys,pathlib; \
-          src=pathlib.Path(sd.__file__).parent/sys.argv[1]; \
-          dst=pathlib.Path(sys.prefix)/sys.argv[2]/sys.argv[3]; \
-          os.makedirs(str(dst.parent),exist_ok=True); \
-          dst.unlink(missing_ok=True); \
-          dst.symlink_to(src); \
-          print(str(src)+sys.argv[4]+str(dst))' \
-         libsndfile_x86_64.so lib libsndfile.so.1 ' -> '"
+         '{SNDFILE_LINK_SCRIPT}' \
+         {SNDFILE_LINK_SOURCE} lib {SNDFILE_LINK_TARGET} ' -> '"
     );
     run_wsl_command(
         &link_sndfile_script,
@@ -724,11 +971,23 @@ impl OmniAsrWorker {
     }
 
     fn spawn_native(config: &OmniAsrConfig) -> Result<Child, String> {
-        Command::new(config.native_python_path())
+        let mut command = Command::new(config.native_python_path());
+        command
             .arg("-u")
             .arg(&config.worker_script_path)
             .env("HF_HUB_DISABLE_PROGRESS_BARS", "0")
-            .env("TQDM_FORCE", "1")
+            .env("TQDM_FORCE", "1");
+
+        #[cfg(target_os = "linux")]
+        command.env(
+            "LD_LIBRARY_PATH",
+            native_ld_library_path(
+                &config.venv_path,
+                std::env::var_os("LD_LIBRARY_PATH").as_deref(),
+            ),
+        );
+
+        command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -1022,13 +1281,22 @@ impl Drop for SetupLock {
     }
 }
 
+#[derive(Debug)]
 struct PythonCandidate {
     command: String,
     prefix_args: Vec<String>,
 }
 
-fn detect_native_python() -> Result<PythonCandidate, String> {
-    let candidates = if cfg!(windows) {
+impl PythonCandidate {
+    fn display_command(&self) -> String {
+        format!("{} {}", self.command, self.prefix_args.join(" "))
+            .trim()
+            .to_string()
+    }
+}
+
+fn native_python_candidates() -> Vec<PythonCandidate> {
+    if cfg!(windows) {
         vec![
             PythonCandidate {
                 command: "py".into(),
@@ -1046,30 +1314,83 @@ fn detect_native_python() -> Result<PythonCandidate, String> {
                 prefix_args: vec![],
             },
             PythonCandidate {
+                command: "python3.12".into(),
+                prefix_args: vec![],
+            },
+            PythonCandidate {
+                command: "python3.11".into(),
+                prefix_args: vec![],
+            },
+            PythonCandidate {
+                command: "python3.10".into(),
+                prefix_args: vec![],
+            },
+            PythonCandidate {
                 command: "python".into(),
                 prefix_args: vec![],
             },
         ]
-    };
+    }
+}
 
-    for candidate in candidates {
-        if command_works(&candidate.command, &candidate.prefix_args) {
+fn unsupported_python_version(version: &str) -> Option<String> {
+    let version = version.strip_prefix("Python ")?;
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+
+    if major == 3 && (10..=12).contains(&minor) {
+        None
+    } else {
+        Some(format!("{major}.{minor}"))
+    }
+}
+
+fn detect_native_python() -> Result<PythonCandidate, String> {
+    let mut found_unsupported_python_version: Option<String> = None;
+
+    for candidate in native_python_candidates() {
+        if let Some(version) = command_version(&candidate.command, &candidate.prefix_args) {
+            if let Some(version) = unsupported_python_version(&version) {
+                found_unsupported_python_version = Some(version);
+                continue;
+            }
+
             return Ok(candidate);
         }
+    }
+
+    if let Some(version) = found_unsupported_python_version {
+        return Err(format!(
+            "Python {version} is not supported for omni-asr. Install Python 3.10, 3.11, or 3.12."
+        ));
     }
 
     Err("Python 3 was not found. Install Python 3 to enable omni-asr.".into())
 }
 
-fn command_works(command: &str, prefix_args: &[String]) -> bool {
-    Command::new(command)
+fn command_version(command: &str, prefix_args: &[String]) -> Option<String> {
+    let output = Command::new(command)
         .args(prefix_args)
         .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return Some(stdout);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return Some(stderr);
+    }
+
+    None
 }
 
 pub fn model_storage_exists(config: &OmniAsrConfig) -> bool {
@@ -1078,25 +1399,245 @@ pub fn model_storage_exists(config: &OmniAsrConfig) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::locale_to_fairseq_lang;
+    use super::{
+        check_native_python_available, cuda_variant_for_gpu_info, detect_native_python,
+        fairseq2_index_for_variant, install_native_runtime_packages, locale_to_fairseq_lang,
+        native_ld_library_path, OmniAsrConfig, FAIRSEQ2_CPU_INDEX, FAIRSEQ2_CUDA_BLACKWELL_INDEX,
+        FAIRSEQ2_CUDA_INDEX, INSTALL_LAYOUT_VERSION, REQUIREMENTS,
+    };
+    use std::ffi::OsStr;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
+
+    fn path_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
-    fn maps_bcp47_locales_to_fairseq_codes() {
+    fn locale_conversions() {
         assert_eq!(locale_to_fairseq_lang("en-US"), "eng_Latn");
-        assert_eq!(locale_to_fairseq_lang("es-ES"), "spa_Latn");
-        assert_eq!(locale_to_fairseq_lang("pt-BR"), "por_Latn");
-    }
-
-    #[test]
-    fn preserves_existing_fairseq_codes() {
         assert_eq!(locale_to_fairseq_lang("eng_Latn"), "eng_Latn");
-        assert_eq!(locale_to_fairseq_lang("ara_Arab"), "ara_Arab");
-    }
-
-    #[test]
-    fn unknown_or_auto_locale_falls_back_to_auto_detect() {
         assert_eq!(locale_to_fairseq_lang("auto"), "");
         assert_eq!(locale_to_fairseq_lang(""), "");
-        assert_eq!(locale_to_fairseq_lang("xx-YY"), "");
+    }
+
+    #[test]
+    fn variant_indexes() {
+        assert_eq!(fairseq2_index_for_variant("cpu"), FAIRSEQ2_CPU_INDEX);
+        assert_eq!(fairseq2_index_for_variant("cu124"), FAIRSEQ2_CUDA_INDEX);
+        assert_eq!(
+            fairseq2_index_for_variant("cu128"),
+            FAIRSEQ2_CUDA_BLACKWELL_INDEX
+        );
+    }
+
+    #[test]
+    fn picks_blackwell_cuda_stack_only_for_new_gpus() {
+        assert_eq!(
+            cuda_variant_for_gpu_info(Some("NVIDIA GeForce RTX 5090 Laptop GPU"), None),
+            "cu128"
+        );
+        assert_eq!(cuda_variant_for_gpu_info(None, Some("12.0")), "cu128");
+        assert_eq!(
+            cuda_variant_for_gpu_info(Some("NVIDIA RTX 5000 Ada Generation"), None),
+            "cu124"
+        );
+        assert_eq!(cuda_variant_for_gpu_info(None, Some("8.9")), "cu124");
+    }
+
+    #[test]
+    fn ld_library_path() {
+        let venv = PathBuf::from("/tmp/venv");
+        assert_eq!(native_ld_library_path(&venv, None), "/tmp/venv/lib");
+        assert_eq!(
+            native_ld_library_path(&venv, Some(OsStr::new("/usr/lib"))),
+            "/tmp/venv/lib:/usr/lib"
+        );
+    }
+
+    #[test]
+    fn stamp_layout_tracking() {
+        let config = OmniAsrConfig {
+            runtime_root: PathBuf::from("/tmp/runtime"),
+            worker_script_path: PathBuf::from("/tmp/runtime/worker.py"),
+            requirements_path: PathBuf::from("/tmp/runtime/requirements.txt"),
+            venv_path: PathBuf::from("/tmp/runtime/venv"),
+            models_dir: PathBuf::from("/tmp/runtime/models"),
+            model: "omniASR_CTC_300M".into(),
+            device: "cpu".into(),
+            lang: String::new(),
+            use_wsl: false,
+            wsl_venv_linux_path: String::new(),
+        };
+        assert!(config
+            .install_stamp_contents()
+            .contains(&format!("# layout={INSTALL_LAYOUT_VERSION}")));
+    }
+
+    #[test]
+    fn rejects_old_layout_stamp() {
+        let tempdir = tempdir().unwrap();
+        let runtime_root = tempdir.path().join("runtime");
+        let venv_path = runtime_root.join("venv");
+        let python_path = venv_path.join("bin").join("python3");
+        fs::create_dir_all(python_path.parent().unwrap()).unwrap();
+        fs::write(&python_path, "").unwrap();
+
+        let config = OmniAsrConfig {
+            runtime_root: runtime_root.clone(),
+            worker_script_path: runtime_root.join("worker.py"),
+            requirements_path: runtime_root.join("requirements.txt"),
+            venv_path,
+            models_dir: runtime_root.join("models"),
+            model: "omniASR_CTC_300M".into(),
+            device: "cuda".into(),
+            lang: String::new(),
+            use_wsl: false,
+            wsl_venv_linux_path: String::new(),
+        };
+        fs::write(
+            config.install_stamp_path(),
+            format!("{REQUIREMENTS}\n# variant=cu124\n# layout=2"),
+        )
+        .unwrap();
+        assert!(!config.is_installed());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pip_install_commands_cuda_variants() {
+        fn record_commands(variant: &str) -> String {
+            let tempdir = tempdir().unwrap();
+            let python_path = tempdir.path().join("python3");
+            let log_path = tempdir.path().join("commands.log");
+            fs::write(&log_path, "").unwrap();
+
+            let script_path = tempdir.path().join("python3");
+            fs::write(
+                &script_path,
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$OMNI_ASR_TEST_LOG\"\nexit 0\n",
+            )
+            .unwrap();
+            let mut perms = fs::metadata(&script_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).unwrap();
+
+            std::env::set_var("OMNI_ASR_TEST_LOG", &log_path);
+            install_native_runtime_packages(&python_path, variant, |_| {}).unwrap();
+            std::env::remove_var("OMNI_ASR_TEST_LOG");
+
+            fs::read_to_string(&log_path).unwrap()
+        }
+
+        let legacy_commands = record_commands("cu124");
+        assert!(legacy_commands.contains("torch==2.6.0"));
+        assert!(legacy_commands.contains("https://download.pytorch.org/whl/cu124"));
+        assert!(legacy_commands.contains("https://fair.pkg.atmeta.com/fairseq2/whl/pt2.6.0/cu124"));
+
+        let blackwell_commands = record_commands("cu128");
+        assert!(blackwell_commands.contains("torch==2.8.0"));
+        assert!(blackwell_commands.contains("https://download.pytorch.org/whl/cu128"));
+        assert!(
+            blackwell_commands.contains("https://fair.pkg.atmeta.com/fairseq2/whl/pt2.8.0/cu128")
+        );
+    }
+
+    #[cfg(unix)]
+    mod python_detection {
+        use super::*;
+        use std::env;
+        use std::ffi::OsString;
+        use std::path::Path;
+
+        struct PathGuard(Option<OsString>);
+        impl PathGuard {
+            fn set(path: &Path) -> Self {
+                let original = env::var_os("PATH");
+                env::set_var("PATH", path);
+                Self(original)
+            }
+        }
+        impl Drop for PathGuard {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(p) => env::set_var("PATH", p),
+                    None => env::remove_var("PATH"),
+                }
+            }
+        }
+
+        fn write_python(dir: &Path, name: &str, version: Option<&str>) {
+            let content = match version {
+                Some(v) => format!("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\necho '{v}'\nexit 0\nfi\nexit 1\n"),
+                None => "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 0; fi\nexit 1\n".into(),
+            };
+            let path = dir.join(name);
+            fs::write(&path, content).unwrap();
+            let mut perms = fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&path, perms).unwrap();
+        }
+
+        fn run_test(cases: &[(&str, Option<&str>)]) -> (tempfile::TempDir, PathGuard) {
+            let _guard = path_lock().lock().unwrap();
+            let td = tempdir().unwrap();
+            for (name, ver) in cases {
+                write_python(td.path(), name, *ver);
+            }
+            let guard = PathGuard::set(td.path());
+            (td, guard)
+        }
+
+        #[test]
+        fn selects_supported_python() {
+            let (_td, _guard) = run_test(&[
+                ("python3", Some("Python 3.13.0")),
+                ("python", Some("Python 3.12.9")),
+            ]);
+            assert_eq!(detect_native_python().unwrap().command, "python");
+            assert_eq!(check_native_python_available().unwrap(), "python");
+        }
+
+        #[test]
+        fn selects_versioned_python() {
+            let (_td, _guard) = run_test(&[("python3.11", Some("Python 3.11.11"))]);
+            assert_eq!(detect_native_python().unwrap().command, "python3.11");
+        }
+
+        #[test]
+        fn rejects_unsupported_version() {
+            let (_td, _guard) = run_test(&[("python3", Some("Python 3.13.0"))]);
+            assert!(detect_native_python().unwrap_err().contains("3.13"));
+            assert!(check_native_python_available()
+                .unwrap_err()
+                .contains("3.13"));
+        }
+
+        #[test]
+        fn rejects_old_version() {
+            let (_td, _guard) = run_test(&[("python3", Some("Python 3.9.0"))]);
+            assert!(detect_native_python().unwrap_err().contains("3.9"));
+        }
+
+        #[test]
+        fn prefers_explicit_versions() {
+            let (_td, _guard) = run_test(&[
+                ("python3", Some("Python 3.13.0")),
+                ("python3.10", Some("Python 3.10.0")),
+            ]);
+            assert_eq!(detect_native_python().unwrap().command, "python3.10");
+        }
+
+        #[test]
+        fn skips_commands_without_version() {
+            let (_td, _guard) =
+                run_test(&[("python3", None), ("python3.12", Some("Python 3.12.0"))]);
+            assert_eq!(detect_native_python().unwrap().command, "python3.12");
+        }
     }
 }


### PR DESCRIPTION
- Add support for NVIDIA Blackwell GPUs (RTX 50xx) with cu128 CUDA variant
- Detect GPU compute capability via nvidia-smi to select correct variant
- Add version validation for Python 3.10-3.12 (reject 3.9 and 3.13+)
- Set LD_LIBRARY_PATH on Linux to find CUDA libraries in venv
- Fix libsndfile.so.1 symlink for fairseq2 audio support
- Track install layout version in stamp for migration detection
- Allow OPENCASSAVA_OMNI_ASR_CUDA_VARIANT env override for manual selection

closes #1 