### PR TITLE
[codex] Surface suggestion controls for issue #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] - Next version
+
+### Suggestions controls
+
+- **Suggestion quick controls** - added an easy-to-find live suggestions toggle and
+  cadence control directly in the main app UI instead of burying cadence in
+  Settings only.
+- **Suggestion disable setting** - added a persisted `suggestionsEnabled` setting
+  so users can fully turn off live suggestion checks and overlay surfacing.
+
 All notable changes to OpenCassava are documented here.
 
 Format: `## [version] — title` followed by grouped bullet points.

--- a/crates/opencassava-core/src/settings.rs
+++ b/crates/opencassava-core/src/settings.rs
@@ -85,6 +85,9 @@ pub struct AppSettings {
     )]
     pub suggestion_interval_seconds: u64,
 
+    #[serde(default = "default_true", alias = "suggestions_enabled")]
+    pub suggestions_enabled: bool,
+
     #[serde(default, alias = "kb_folder_path")]
     pub kb_folder_path: Option<String>,
 
@@ -211,6 +214,7 @@ impl Default for AppSettings {
             open_ai_embed_base_url: default_openai_embed_url(),
             open_ai_embed_model: default_openai_embed_model(),
             suggestion_interval_seconds: default_suggestion_interval_seconds(),
+            suggestions_enabled: default_true(),
             kb_folder_path: None,
             notes_folder_path: default_notes_folder(),
             has_acknowledged_recording_consent: false,
@@ -451,6 +455,18 @@ mod tests {
         s.save_to(path.clone());
         let s2 = AppSettings::load_from(path);
         assert_eq!(s2.suggestion_interval_seconds, 180);
+    }
+
+    #[test]
+    fn suggestions_enabled_defaults_and_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let mut s = AppSettings::load_from(path.clone());
+        assert!(s.suggestions_enabled);
+        s.suggestions_enabled = false;
+        s.save_to(path.clone());
+        let s2 = AppSettings::load_from(path);
+        assert!(!s2.suggestions_enabled);
     }
 
     #[test]

--- a/opencassava/src-tauri/src/engine.rs
+++ b/opencassava/src-tauri/src/engine.rs
@@ -1321,6 +1321,15 @@ pub fn start_transcription(
                     break;
                 }
 
+                let settings = suggestion_state.settings.lock().unwrap().clone();
+                if !settings.suggestions_enabled {
+                    *suggestion_state.overlay_suggestion.lock().unwrap() = None;
+                    if let Some(overlay) = suggestion_app.get_webview_window(OVERLAY_LABEL) {
+                        let _ = overlay.hide();
+                    }
+                    continue;
+                }
+
                 let cutoff =
                     chrono::Utc::now() - chrono::Duration::seconds(suggestion_context_window_secs);
                 let recent_buf = suggestion_recent_utterances
@@ -1361,7 +1370,6 @@ pub fn start_transcription(
                     )
                     .ok();
 
-                let settings = suggestion_state.settings.lock().unwrap().clone();
                 {
                     let mut engine = suggestion_state.suggestion_engine.lock().await;
                     engine.kb_surfacing_system_prompt = settings.kb_surfacing_system_prompt.clone();

--- a/opencassava/src/App.tsx
+++ b/opencassava/src/App.tsx
@@ -161,6 +161,23 @@ function App() {
     setSettings(updated);
   }, []);
 
+  const handleSuggestionSettingsChange = useCallback(
+    async (updates: Partial<Pick<AppSettings, "suggestionsEnabled" | "suggestionIntervalSeconds">>) => {
+      if (!settings) {
+        return;
+      }
+      const nextSettings = { ...settings, ...updates };
+      setSettings(nextSettings);
+      try {
+        await invoke("save_settings", { newSettings: nextSettings });
+      } catch (err) {
+        console.error("Failed to save suggestion settings:", err);
+        setSettings(settings);
+      }
+    },
+    [settings],
+  );
+
   const refreshSttStatus = useCallback(async () => {
     try {
       const status = await invoke<SttStatus>("get_stt_status");
@@ -592,6 +609,10 @@ function App() {
         isSuggestionAnalyzing={isGeneratingSuggestion}
         lastSuggestionCheckAt={lastSuggestionCheckAt}
         lastSuggestionCheckSurfaced={lastSuggestionCheckSurfaced}
+        suggestionsEnabled={settings?.suggestionsEnabled ?? true}
+        suggestionIntervalSeconds={settings?.suggestionIntervalSeconds ?? 30}
+        onSuggestionsEnabledChange={(enabled) => handleSuggestionSettingsChange({ suggestionsEnabled: enabled })}
+        onSuggestionIntervalChange={(seconds) => handleSuggestionSettingsChange({ suggestionIntervalSeconds: seconds })}
         audioLevel={audioLevel}
         audioLevelThem={audioLevelThem}
       />
@@ -671,6 +692,10 @@ function App() {
             kbFileCount={0}
             lastCheckedAt={lastSuggestionCheckAt}
             lastCheckSurfaced={lastSuggestionCheckSurfaced}
+            suggestionsEnabled={settings?.suggestionsEnabled ?? true}
+            suggestionIntervalSeconds={settings?.suggestionIntervalSeconds ?? 30}
+            onSuggestionsEnabledChange={(enabled) => handleSuggestionSettingsChange({ suggestionsEnabled: enabled })}
+            onSuggestionIntervalChange={(seconds) => handleSuggestionSettingsChange({ suggestionIntervalSeconds: seconds })}
             onDismiss={handleDismissSuggestion}
             onInjectTest={(s) =>
               setSuggestions((prev) => [

--- a/opencassava/src/components/ControlBar.tsx
+++ b/opencassava/src/components/ControlBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { WaveformVisualizer } from "./WaveformVisualizer";
+import { SuggestionControls } from "./SuggestionControls";
 import { colors, typography, spacing } from "../theme";
 
 interface Props {
@@ -17,6 +18,10 @@ interface Props {
   isSuggestionAnalyzing?: boolean;
   lastSuggestionCheckAt?: string | null;
   lastSuggestionCheckSurfaced?: boolean | null;
+  suggestionsEnabled?: boolean;
+  suggestionIntervalSeconds?: number;
+  onSuggestionsEnabledChange?: (enabled: boolean) => void;
+  onSuggestionIntervalChange?: (seconds: number) => void;
   audioLevel?: number;
   audioLevelThem?: number;
 }
@@ -57,6 +62,10 @@ export function ControlBar({
   isSuggestionAnalyzing = false,
   lastSuggestionCheckAt = null,
   lastSuggestionCheckSurfaced = null,
+  suggestionsEnabled = true,
+  suggestionIntervalSeconds = 30,
+  onSuggestionsEnabledChange,
+  onSuggestionIntervalChange,
   audioLevel = 0,
   audioLevelThem = 0,
 }: Props) {
@@ -370,7 +379,7 @@ export function ControlBar({
 
       <div style={{ flex: 1 }} />
 
-      <div style={{ display: "flex", alignItems: "center", gap: spacing[2] }}>
+      <div style={{ display: "flex", alignItems: "center", gap: spacing[2], flexWrap: "wrap", justifyContent: "flex-end" }}>
         {kbConnected ? (
           <span style={statusBadgeStyle(colors.accent)}>
             <span>KB</span>
@@ -385,18 +394,34 @@ export function ControlBar({
         {isRunning && !isStopping && (
           <span
             style={statusBadgeStyle(
-              isSuggestionAnalyzing
+              !suggestionsEnabled
+                ? colors.textSecondary
+                : isSuggestionAnalyzing
                 ? colors.them
                 : lastSuggestionCheckSurfaced
                   ? colors.success
                   : colors.textSecondary,
             )}
           >
-            <span style={{ fontSize: 6 }}>{isSuggestionAnalyzing ? "o" : "O"}</span>
+            <span style={{ fontSize: 6 }}>{!suggestionsEnabled ? "O" : isSuggestionAnalyzing ? "o" : "O"}</span>
             <span>
-              {isSuggestionAnalyzing ? "Analyzing" : `Suggestions ${formatRelativeTime(lastSuggestionCheckAt)}`}
+              {!suggestionsEnabled
+                ? "Suggestions off"
+                : isSuggestionAnalyzing
+                  ? "Analyzing"
+                  : `Suggestions ${formatRelativeTime(lastSuggestionCheckAt)}`}
             </span>
           </span>
+        )}
+
+        {onSuggestionsEnabledChange && onSuggestionIntervalChange && (
+          <SuggestionControls
+            suggestionsEnabled={suggestionsEnabled}
+            suggestionIntervalSeconds={suggestionIntervalSeconds}
+            onSuggestionsEnabledChange={onSuggestionsEnabledChange}
+            onSuggestionIntervalChange={onSuggestionIntervalChange}
+            compact
+          />
         )}
       </div>
 

--- a/opencassava/src/components/SettingsView.tsx
+++ b/opencassava/src/components/SettingsView.tsx
@@ -1297,19 +1297,42 @@ export function SettingsView({
               </div>
             )}
             <div style={styles.fieldWrap}>
+              <label style={styles.checkboxLabel}>
+                <input
+                  type="checkbox"
+                  checked={settings.suggestionsEnabled}
+                  onChange={(e) =>
+                    saveSettings({
+                      ...settings,
+                      suggestionsEnabled: e.target.checked,
+                    })
+                  }
+                />
+                <span>Enable live suggestions</span>
+              </label>
+              <span style={{ fontSize: typography.sm, color: colors.textMuted, marginTop: 4, display: "block" }}>
+                Turn off all live suggestion checks without changing your other AI settings.
+              </span>
+            </div>
+            <div style={styles.fieldWrap}>
               <label style={styles.labelStyle}>Suggestion Cadence</label>
               <input
                 type="number"
                 min={30}
                 step={15}
                 value={settings.suggestionIntervalSeconds}
+                disabled={!settings.suggestionsEnabled}
                 onChange={(e) =>
                   saveSettings({
                     ...settings,
                     suggestionIntervalSeconds: Math.max(30, Number(e.target.value) || 30),
                   })
                 }
-                style={styles.inputStyle}
+                style={{
+                  ...styles.inputStyle,
+                  opacity: settings.suggestionsEnabled ? 1 : 0.6,
+                  cursor: settings.suggestionsEnabled ? "text" : "not-allowed",
+                }}
               />
               <span style={{ fontSize: typography.sm, color: colors.textMuted, marginTop: 4, display: "block" }}>
                 Generate suggestions from the recent conversation every N seconds instead of waiting for trigger phrases.

--- a/opencassava/src/components/SuggestionControls.tsx
+++ b/opencassava/src/components/SuggestionControls.tsx
@@ -1,0 +1,110 @@
+import { colors, spacing, typography } from "../theme";
+
+interface Props {
+  suggestionsEnabled: boolean;
+  suggestionIntervalSeconds: number;
+  onSuggestionsEnabledChange: (enabled: boolean) => void;
+  onSuggestionIntervalChange: (seconds: number) => void;
+  compact?: boolean;
+}
+
+const CADENCE_OPTIONS = [
+  { value: 30, label: "30s" },
+  { value: 45, label: "45s" },
+  { value: 60, label: "1m" },
+  { value: 90, label: "90s" },
+  { value: 120, label: "2m" },
+  { value: 180, label: "3m" },
+];
+
+export function SuggestionControls({
+  suggestionsEnabled,
+  suggestionIntervalSeconds,
+  onSuggestionsEnabledChange,
+  onSuggestionIntervalChange,
+  compact = false,
+}: Props) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: compact ? "center" : "flex-start",
+        justifyContent: "space-between",
+        gap: spacing[3],
+        flexWrap: "wrap",
+        padding: compact ? `${spacing[2]}px ${spacing[3]}px` : spacing[3],
+        background: compact ? colors.surface : colors.surfaceElevated,
+        border: `1px solid ${colors.border}`,
+        borderRadius: compact ? 999 : 12,
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: spacing[1] }}>
+        <span
+          style={{
+            fontSize: compact ? typography.sm : typography.md,
+            fontWeight: 600,
+            color: colors.text,
+          }}
+        >
+          Suggestions
+        </span>
+        {!compact && (
+          <span style={{ fontSize: typography.sm, color: colors.textSecondary, lineHeight: 1.5 }}>
+            Turn live suggestions on or off and adjust how often OpenCassava checks the conversation.
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: spacing[2], flexWrap: "wrap" }}>
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: spacing[2],
+            fontSize: typography.sm,
+            color: colors.text,
+            fontWeight: 500,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={suggestionsEnabled}
+            onChange={(e) => onSuggestionsEnabledChange(e.target.checked)}
+          />
+          Enabled
+        </label>
+
+        <label
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: spacing[2],
+            fontSize: typography.sm,
+            color: suggestionsEnabled ? colors.text : colors.textMuted,
+          }}
+        >
+          <span>Every</span>
+          <select
+            value={String(suggestionIntervalSeconds)}
+            onChange={(e) => onSuggestionIntervalChange(Math.max(30, Number(e.target.value) || 30))}
+            disabled={!suggestionsEnabled}
+            style={{
+              padding: `${spacing[1]}px ${spacing[2]}px`,
+              background: colors.background,
+              color: suggestionsEnabled ? colors.text : colors.textMuted,
+              border: `1px solid ${colors.border}`,
+              borderRadius: 6,
+              cursor: suggestionsEnabled ? "pointer" : "not-allowed",
+            }}
+          >
+            {CADENCE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/opencassava/src/components/SuggestionsView.tsx
+++ b/opencassava/src/components/SuggestionsView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { Suggestion } from "../types";
+import { SuggestionControls } from "./SuggestionControls";
 import { colors, typography, spacing } from "../theme";
 
 interface Props {
@@ -10,6 +11,10 @@ interface Props {
   kbFileCount?: number;
   lastCheckedAt?: string | null;
   lastCheckSurfaced?: boolean | null;
+  suggestionsEnabled?: boolean;
+  suggestionIntervalSeconds?: number;
+  onSuggestionsEnabledChange?: (enabled: boolean) => void;
+  onSuggestionIntervalChange?: (seconds: number) => void;
   onDismiss?: (id: string) => void;
   onInjectTest?: (suggestion: { id: string; kind: string; text: string; kbHits: any[] }) => void;
 }
@@ -395,6 +400,10 @@ export function SuggestionsView({
   kbFileCount = 0,
   lastCheckedAt = null,
   lastCheckSurfaced = null,
+  suggestionsEnabled = true,
+  suggestionIntervalSeconds = 30,
+  onSuggestionsEnabledChange,
+  onSuggestionIntervalChange,
   onDismiss,
   onInjectTest,
 }: Props) {
@@ -420,6 +429,16 @@ export function SuggestionsView({
         }}
       >
         <div style={{ padding: spacing[3] }}>
+          {onSuggestionsEnabledChange && onSuggestionIntervalChange && (
+            <div style={{ marginBottom: spacing[3] }}>
+              <SuggestionControls
+                suggestionsEnabled={suggestionsEnabled}
+                suggestionIntervalSeconds={suggestionIntervalSeconds}
+                onSuggestionsEnabledChange={onSuggestionsEnabledChange}
+                onSuggestionIntervalChange={onSuggestionIntervalChange}
+              />
+            </div>
+          )}
           <button
             onClick={handleInjectTest}
             style={{
@@ -454,6 +473,17 @@ export function SuggestionsView({
         background: colors.background,
       }}
     >
+      {onSuggestionsEnabledChange && onSuggestionIntervalChange && (
+        <div style={{ marginBottom: spacing[3] }}>
+          <SuggestionControls
+            suggestionsEnabled={suggestionsEnabled}
+            suggestionIntervalSeconds={suggestionIntervalSeconds}
+            onSuggestionsEnabledChange={onSuggestionsEnabledChange}
+            onSuggestionIntervalChange={onSuggestionIntervalChange}
+          />
+        </div>
+      )}
+
       <button
         onClick={handleInjectTest}
         style={{

--- a/opencassava/src/types.ts
+++ b/opencassava/src/types.ts
@@ -50,6 +50,7 @@ export interface AppSettings {
   openAiEmbedBaseUrl: string;
   openAiEmbedModel: string;
   suggestionIntervalSeconds: number;
+  suggestionsEnabled: boolean;
   kbFolderPath: string | null;
   notesFolderPath: string;
   hasAcknowledgedRecordingConsent: boolean;


### PR DESCRIPTION
## Summary
- surface live suggestion controls in easier-to-find places in the app UI
- add a persisted `suggestionsEnabled` setting so suggestions can be fully disabled
- track the change in `CHANGELOG.md` under an unreleased next-version section

## Why
Issue #26 reports that disabling suggestions and adjusting their frequency is currently buried in Settings. This change makes those controls visible where users actually interact with suggestions while preserving the existing Settings path.

## Root cause
The app only exposed suggestion cadence deep in Settings, and there was no explicit persisted on/off setting for live suggestions.

## User impact
Users can now turn suggestions on or off and change cadence directly from the main live UI and the Suggestions tab, without hunting through Settings.

## Validation
- `cargo fmt --all --check`
- `cargo test -p opencassava-core suggestion_interval_defaults_and_persists -- --nocapture` currently blocked by missing local dependency path `.build/whisper-rs`
- `npm run build` currently blocked because `typescript` is not installed in `opencassava/node_modules`

Fixes #26.