### PR TITLE
[codex] fix frontend lint workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,28 @@ permissions:
   contents: read
 
 jobs:
+  frontend-lint:
+    name: Frontend lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opencassava/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: opencassava
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint
+
   unit-tests:
     name: Rust unit tests (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CLAUDE.md
 AGENTS.md
 node_modules/
 opencassava/node_modules/
+opencassava/.eslintcache
 *.log
 target/
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ The release workflow reads this file and extracts the section that matches the
 current tag, so keep each release block between its own `## [x.y.z]` header
 and the next one.
 
+## [Unreleased] — next version
+
+### Developer workflow
+
+- **Root lint entrypoint** — added a repo-root `npm run lint` / `npm run lint:fix`
+  path that delegates to the Tauri frontend so contributors and CI use the same
+  command.
+- **Scoped frontend ESLint** — tightened the frontend lint command to target the
+  TypeScript React source, local Node build scripts, and the ESLint config
+  itself while ignoring generated directories.
+- **Typed lint cleanup** — removed the existing frontend lint failures that were
+  blocking a real enforced lint pass, including unsafe `any` usage, stale effect
+  dependencies, and unused props/state.
+- **PR lint job** — pull requests now install frontend dependencies and run the
+  frontend lint check in GitHub Actions instead of only running Rust tests.
+- **Lint cache ignored** — the frontend ESLint cache file is now ignored so local
+  lint runs do not dirty the worktree.
+
 ---
 
 ## [Unreleased] — next version

--- a/opencassava/eslint.config.js
+++ b/opencassava/eslint.config.js
@@ -6,18 +6,39 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'node_modules', 'src-tauri']),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ['eslint.config.js', 'scripts/**/*.mjs'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+    ],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node,
+    },
+  },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
+      ecmaVersion: 'latest',
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
+      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/require-await': 'off',
+      'react-hooks/set-state-in-effect': 'off',
     },
   },
 ])

--- a/opencassava/package-lock.json
+++ b/opencassava/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencassavatauri",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencassavatauri",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "react": "^19.2.4",

--- a/opencassava/package.json
+++ b/opencassava/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "node ./scripts/vite-dev.mjs",
     "build": "tsc -b ./tsconfig.app.json && node ./scripts/vite-build.mjs",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 --cache --cache-location .eslintcache \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"eslint.config.js\"",
+    "lint:fix": "npm run lint -- --fix",
     "preview": "vite preview",
     "tauri": "node ./scripts/run-tauri.mjs"
   },

--- a/opencassava/src/App.tsx
+++ b/opencassava/src/App.tsx
@@ -5,6 +5,7 @@ import { listen } from "@tauri-apps/api/event";
 import type {
   Utterance,
   Suggestion,
+  KBResult,
   AppSettings,
   EnhancedNotes,
   SessionDetails,
@@ -302,7 +303,11 @@ function App() {
   useKeyboardShortcuts({
     onStartStop: () => {
       if (modelState === "ready" && !isStopping && !parakeetWarming && !omniAsrWarming) {
-        isRunning ? handleStop() : handleStart();
+        if (isRunning) {
+          void handleStop();
+        } else {
+          void handleStart();
+        }
       }
     },
     onFocusSearch: () => {
@@ -393,7 +398,7 @@ function App() {
         }
       }),
 
-      listen<{ id: string; kind?: "knowledge_base" | "smart_question"; text: string; kbHits?: any[] }>("suggestion", (e) => {
+      listen<{ id: string; kind?: "knowledge_base" | "smart_question"; text: string; kbHits?: KBResult[] }>("suggestion", (e) => {
         setIsGeneratingSuggestion(false);
         setSuggestions((prev) => [
           ...prev,
@@ -888,7 +893,6 @@ function App() {
                 ...prev,
                 {
                   ...s,
-                  kind: s.kind as Suggestion["kind"],
                   timestamp: new Date().toISOString(),
                 },
               ])

--- a/opencassava/src/components/ControlBar.tsx
+++ b/opencassava/src/components/ControlBar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { WaveformVisualizer } from "./WaveformVisualizer";
 import { SuggestionControls } from "./SuggestionControls";
+import type { AppSettings } from "../types";
 import { colors, typography, spacing } from "../theme";
 
 interface Props {
@@ -76,12 +77,13 @@ export function ControlBar({
   const [duration, setDuration] = useState(0);
   const durationRef = useRef(0);
   const intervalRef = useRef<number | null>(null);
+  const loadSettings = () => invoke<AppSettings>("get_settings");
 
   useEffect(() => {
     Promise.all([
       invoke<string[]>("list_mic_devices"),
       invoke<string[]>("list_sys_audio_devices"),
-      invoke<any>("get_settings"),
+      loadSettings(),
     ]).then(([mics, sysDevs, s]) => {
       setDevices(mics);
       setSysDevices(sysDevs);
@@ -116,11 +118,12 @@ export function ControlBar({
   }, [isRunning, isStopping]);
 
   const isBusy = isRunning || isStopping;
+  const displayedDuration = isBusy ? duration : 0;
 
   const handleDeviceChange = async (device: string) => {
     setSelectedDevice(device);
     try {
-      const settings = await invoke<any>("get_settings");
+      const settings = await loadSettings();
       await invoke("save_settings", {
         newSettings: { ...settings, inputDeviceName: device === "default" ? null : device },
       });
@@ -132,7 +135,7 @@ export function ControlBar({
   const handleSysDeviceChange = async (device: string) => {
     setSelectedSysDevice(device);
     try {
-      const settings = await invoke<any>("get_settings");
+      const settings = await loadSettings();
       await invoke("save_settings", {
         newSettings: { ...settings, systemAudioDeviceName: device === "default" ? null : device },
       });
@@ -353,7 +356,7 @@ export function ControlBar({
               letterSpacing: "0.5px",
             }}
           >
-            {formatDuration(duration)}
+            {formatDuration(displayedDuration)}
           </span>
 
           <div style={{ display: "flex", flexDirection: "column", gap: spacing[1] }}>

--- a/opencassava/src/components/NotesView.tsx
+++ b/opencassava/src/components/NotesView.tsx
@@ -60,7 +60,7 @@ export function NotesView({ sessionId, initialNotes, onNotesChange, isRunning }:
   const [lastRegenAt, setLastRegenAt] = useState<Date | null>(null);
   const [showHistory, setShowHistory] = useState(false);
   const [historyViewIndex, setHistoryViewIndex] = useState<number | null>(null);
-  const [_secondsSinceRegen, setSecondsSinceRegen] = useState<number | null>(null);
+  const [, setSecondsSinceRegen] = useState<number | null>(null);
 
   // Refs to avoid stale closures in interval
   const isGeneratingRef = useRef(isGenerating);
@@ -155,7 +155,7 @@ export function NotesView({ sessionId, initialNotes, onNotesChange, isRunning }:
     setError(null);
     setShowThoughts(false);
     setHistoryViewIndex(null);
-  }, [sessionId, initialNotes]);
+  }, [sessionId, initialNotes, templates]);
 
   // Turn off auto-regen when recording stops
   useEffect(() => {

--- a/opencassava/src/components/SettingsView.tsx
+++ b/opencassava/src/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { ApiKeys, AppSettings, SttStatus } from "../types";
@@ -163,6 +163,7 @@ export function SettingsView({
   // Prerequisite check state
   const [wsl2Status, setWsl2Status] = useState<{ ok: boolean; message: string } | null>(null);
   const [pythonStatus, setPythonStatus] = useState<{ ok: boolean; message: string } | null>(null);
+  const isWindows = navigator.userAgent.toLowerCase().includes("windows");
 
 
   useEffect(() => {
@@ -191,14 +192,14 @@ export function SettingsView({
     } else {
       setPythonStatus(null);
     }
-  }, [settings?.sttProvider, activeTab]);
+  }, [settings, activeTab, isWindows]);
 
 
   useEffect(() => {
     if (initialSettings) {
       setSettings(initialSettings);
       if (initialSettings.kbFolderPath) {
-        countKBFiles(initialSettings.kbFolderPath);
+        void countKBFiles();
       } else {
         setKbFileCount(0);
       }
@@ -209,37 +210,37 @@ export function SettingsView({
       .then((loadedSettings) => {
         setSettings(loadedSettings);
         if (loadedSettings.kbFolderPath) {
-          countKBFiles(loadedSettings.kbFolderPath);
+          void countKBFiles();
         } else {
           setKbFileCount(0);
         }
       })
       .catch((err) => setError(String(err)));
-  }, [initialSettings]);
+  }, [initialSettings, countKBFiles]);
 
   useEffect(() => {
     if (settings?.kbFolderPath) {
-      syncKnowledgeBase();
+      void syncKnowledgeBase();
     } else {
       setKbStatus(null);
       setIsIndexingKb(false);
     }
-  }, [settings?.kbFolderPath]);
+  }, [settings?.kbFolderPath, syncKnowledgeBase]);
 
-  const countKBFiles = async (_path: string) => {
+  const countKBFiles = useCallback(async () => {
     try {
       setKbFileCount(0);
     } catch {
       setKbFileCount(0);
     }
-  };
+  }, []);
 
   const flashSaved = () => {
     setSaved(true);
     setTimeout(() => setSaved(false), 1500);
   };
 
-  const syncKnowledgeBase = async () => {
+  const syncKnowledgeBase = useCallback(async () => {
     if (!settings?.kbFolderPath) {
       setKbStatus(null);
       setIsIndexingKb(false);
@@ -262,7 +263,7 @@ export function SettingsView({
     } finally {
       setIsIndexingKb(false);
     }
-  };
+  }, [settings?.kbFolderPath]);
 
   const saveSettings = async (updated: AppSettings) => {
     try {
@@ -326,7 +327,7 @@ export function SettingsView({
         const updated = { ...settings, [key]: selected };
         await saveSettings(updated);
         if (key === "kbFolderPath") {
-          countKBFiles(selected);
+          void countKBFiles();
         }
       }
     } catch (err) {
@@ -349,8 +350,6 @@ export function SettingsView({
     (settings.llmProvider === "ollama" && settings.embeddingProvider === "ollama") ||
     (settings.llmProvider === "openai" && settings.embeddingProvider === "openai" &&
       isLocalUrl(settings.openAiLlmBaseUrl) && isLocalUrl(settings.openAiEmbedBaseUrl));
-
-  const isWindows = navigator.userAgent.toLowerCase().includes("windows");
 
   // Local styles for SettingsView
   const styles = {

--- a/opencassava/src/components/SuggestionsView.tsx
+++ b/opencassava/src/components/SuggestionsView.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { Suggestion } from "../types";
+import type { KBResult, Suggestion } from "../types";
 import { SuggestionControls } from "./SuggestionControls";
 import { colors, typography, spacing } from "../theme";
 
@@ -16,7 +16,7 @@ interface Props {
   onSuggestionsEnabledChange?: (enabled: boolean) => void;
   onSuggestionIntervalChange?: (seconds: number) => void;
   onDismiss?: (id: string) => void;
-  onInjectTest?: (suggestion: { id: string; kind: string; text: string; kbHits: any[] }) => void;
+  onInjectTest?: (suggestion: { id: string; kind: Suggestion["kind"]; text: string; kbHits: KBResult[] }) => void;
 }
 
 interface ParsedBullet {

--- a/opencassava/src/components/WaveformVisualizer.tsx
+++ b/opencassava/src/components/WaveformVisualizer.tsx
@@ -5,7 +5,6 @@ interface Props {
   level: number; // 0-1
   isActive: boolean;
   color?: string;
-  colorLight?: string;
 }
 
 const BAR_COUNT = 12;
@@ -25,7 +24,6 @@ export function WaveformVisualizer({
   level,
   isActive,
   color = colors.accent,
-  colorLight: _colorLight = colors.accentLight,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animFrameRef = useRef<number>(0);

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "lint": "npm --prefix ./opencassava run lint",
+    "lint:fix": "npm --prefix ./opencassava run lint:fix"
+  },
   "devDependencies": {
     "@tauri-apps/cli": "^2.10.1"
   }


### PR DESCRIPTION
## Summary

This repairs the frontend lint workflow so the repository has a single reliable lint path from the repo root and PRs actually enforce it.

## What changed

- added repo-root `npm run lint` and `npm run lint:fix` commands that delegate to the Tauri frontend
- tightened the frontend ESLint command to lint the React TypeScript source, local Node/Vite scripts, and the ESLint config itself
- upgraded the frontend ESLint config to a practical typed TypeScript setup while keeping rules aligned with the current codebase
- fixed the existing frontend lint violations that blocked enabling a real enforced lint pass
- ignored the frontend ESLint cache file so local lint runs do not dirty the worktree
- added an unreleased changelog entry so the next release notes track this workflow change without bumping the version yet
- added a PR workflow job that installs frontend dependencies and runs the frontend lint check

## Why

The repo already had frontend ESLint configuration, but it was not wired into a dependable project workflow. Lint only existed inside `opencassava`, the root package had no matching entrypoint, and the PR workflow labeled as linting was only running Rust tests. That meant frontend linting was easy to skip and CI was not enforcing it.

## Impact

Developers now have one documented command to run lint from the repository root, and pull requests will fail when the frontend lint check regresses.

## Validation

- `npm run lint`

## Root cause

The tooling existed in pieces but was not connected: package scripts, ESLint scope, ignored artifacts, and CI were not aligned around the same frontend lint command.